### PR TITLE
Add github.com prefix to module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/text/language"
 
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/speechly/identity"
-	"speechly/slu-client/pkg/speechly/slu"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/speechly/identity"
+	"github.com/speechly/slu-client/pkg/speechly/slu"
 )
 
 const (

--- a/cmd/command/config.go
+++ b/cmd/command/config.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"speechly/slu-client/internal/application"
-	"speechly/slu-client/internal/os"
+	"github.com/speechly/slu-client/internal/application"
+	"github.com/speechly/slu-client/internal/os"
 )
 
 const (

--- a/cmd/command/root.go
+++ b/cmd/command/root.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"speechly/slu-client/internal/application"
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/internal/application"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 const (

--- a/cmd/command/slu.go
+++ b/cmd/command/slu.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"speechly/slu-client/internal/application"
-	"speechly/slu-client/internal/os"
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/internal/application"
+	"github.com/speechly/slu-client/internal/os"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 var (

--- a/cmd/command/token.go
+++ b/cmd/command/token.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"speechly/slu-client/internal/application"
+	"github.com/speechly/slu-client/internal/application"
 )
 
 const tokenFilename = "access_token"

--- a/cmd/command/wav.go
+++ b/cmd/command/wav.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"speechly/slu-client/internal/os"
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/audio/wav"
+	"github.com/speechly/slu-client/internal/os"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/audio/wav"
 )
 
 var wavCmd = &cobra.Command{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"speechly/slu-client/cmd/command"
+	"github.com/speechly/slu-client/cmd/command"
 )
 
 func main() {

--- a/examples/microphone.go
+++ b/examples/microphone.go
@@ -12,10 +12,10 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/text/language"
 
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly/identity"
-	"speechly/slu-client/pkg/speechly/slu"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly/identity"
+	"github.com/speechly/slu-client/pkg/speechly/slu"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module speechly/slu-client
+module github.com/speechly/slu-client
 
 go 1.14
 

--- a/internal/application/api_token.go
+++ b/internal/application/api_token.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly"
-	"speechly/slu-client/pkg/speechly/identity"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/pkg/speechly/identity"
 )
 
 const (

--- a/internal/application/logger.go
+++ b/internal/application/logger.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 // NewLogger returns a new logger that writes to out with specified level.

--- a/internal/application/recognise.go
+++ b/internal/application/recognise.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"net/url"
 
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/audio/wav"
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly"
-	"speechly/slu-client/pkg/speechly/slu"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/audio/wav"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/pkg/speechly/slu"
 )
 
 // RecogniseMicrophone uses Speechly SLU API to recognise audio from the microphone.

--- a/pkg/audio/player.go
+++ b/pkg/audio/player.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gordonklaus/portaudio"
 	"github.com/hashicorp/go-multierror"
 
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 // Player is an audio player that reads data from specified audio source,

--- a/pkg/audio/record_stream.go
+++ b/pkg/audio/record_stream.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gordonklaus/portaudio"
 	"github.com/hashicorp/go-multierror"
 
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 // RecordStream is an audio stream that implements io.WriterTo interface,

--- a/pkg/audio/recorder.go
+++ b/pkg/audio/recorder.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gordonklaus/portaudio"
 	"github.com/hashicorp/go-multierror"
 
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 // Recorder is an audio recorder that reads data from default OS audio input and writes data to specified  destination.

--- a/pkg/audio/wav/player.go
+++ b/pkg/audio/wav/player.go
@@ -3,8 +3,8 @@ package wav
 import (
 	"encoding/binary"
 
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 // NewFilePlayer returns new audio.Player which uses a WAV reader as an audio source.

--- a/pkg/audio/wav/reader.go
+++ b/pkg/audio/wav/reader.go
@@ -10,7 +10,7 @@ import (
 	gaudio "github.com/go-audio/audio"
 	"github.com/go-audio/wav"
 
-	"speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/audio"
 )
 
 // WAV reader errors.

--- a/pkg/audio/wav/recorder.go
+++ b/pkg/audio/wav/recorder.go
@@ -3,8 +3,8 @@ package wav
 import (
 	"os"
 
-	"speechly/slu-client/pkg/audio"
-	"speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/logger"
 )
 
 // NewFileRecorder returns a new audio.Recorder with a WAV writer set as destination.

--- a/pkg/audio/wav/writer.go
+++ b/pkg/audio/wav/writer.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-audio/wav"
 	"github.com/hashicorp/go-multierror"
 
-	"speechly/slu-client/pkg/audio"
+	"github.com/speechly/slu-client/pkg/audio"
 )
 
 // Supported WAV encodings.

--- a/pkg/speechly/identity/client.go
+++ b/pkg/speechly/identity/client.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 
-	pgrpc "speechly/slu-client/internal/grpc"
-	"speechly/slu-client/pkg/speechly"
+	pgrpc "github.com/speechly/slu-client/internal/grpc"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 const (

--- a/pkg/speechly/identity/token.go
+++ b/pkg/speechly/identity/token.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/uuid"
 
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 // GetAccessToken is a convenience wrapper that instantiates a new identity client and calls Login on it.

--- a/pkg/speechly/slu/client.go
+++ b/pkg/speechly/slu/client.go
@@ -8,9 +8,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
-	pgrpc "speechly/slu-client/internal/grpc"
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly"
+	pgrpc "github.com/speechly/slu-client/internal/grpc"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 // Config is the configuration of an SLU recognition stream.

--- a/pkg/speechly/slu/entity.go
+++ b/pkg/speechly/slu/entity.go
@@ -1,8 +1,8 @@
 package slu
 
 import (
-	"speechly/slu-client/internal/json"
-	"speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/internal/json"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 // Entity is the entity detected by SLU API.

--- a/pkg/speechly/slu/handler.go
+++ b/pkg/speechly/slu/handler.go
@@ -8,8 +8,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 var (

--- a/pkg/speechly/slu/intent.go
+++ b/pkg/speechly/slu/intent.go
@@ -1,6 +1,6 @@
 package slu
 
-import "speechly/slu-client/pkg/speechly"
+import "github.com/speechly/slu-client/pkg/speechly"
 
 // Intent is the intent detected by SLU API.
 type Intent struct {

--- a/pkg/speechly/slu/segment.go
+++ b/pkg/speechly/slu/segment.go
@@ -3,7 +3,7 @@ package slu
 import (
 	"errors"
 
-	"speechly/slu-client/internal/json"
+	"github.com/speechly/slu-client/internal/json"
 )
 
 // Segment represents a single SLU segment, which is bounded by a single SLU intent.

--- a/pkg/speechly/slu/stream.go
+++ b/pkg/speechly/slu/stream.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"sync"
 
-	"speechly/slu-client/pkg/logger"
-	"speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/pkg/logger"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 // AudioSource is the interface that represents the audio data source

--- a/pkg/speechly/slu/transcript.go
+++ b/pkg/speechly/slu/transcript.go
@@ -3,8 +3,8 @@ package slu
 import (
 	"errors"
 
-	"speechly/slu-client/internal/json"
-	"speechly/slu-client/pkg/speechly"
+	"github.com/speechly/slu-client/internal/json"
+	"github.com/speechly/slu-client/pkg/speechly"
 )
 
 var errNilValue = errors.New("cannot parse nil value")


### PR DESCRIPTION
### What

Add github.com prefix to module name.

### Why

To make using it as a library simpler for most cases.

### Verification

Import path should now be prefixed with `github.com/`.
