### PR TITLE
Ensure that context handler reads drain the channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
-CMD         := ./cmd
+VERSION     := $(shell git describe --tags)
+AUTHOR      := $(shell git config user.email)
+TIME        := $(shell date +%FT%T%z)
+
 NAME        := speechly-slu
 BUILDNAME   ?= ./bin/$(NAME)
 INSTALLNAME := ${GOBIN}/$(NAME)
 LINTNAME    := .linted
 PROTONAME   := pkg/speechly/*.pb.go
+
+CMD         := ./cmd
 SOURCES     := $(shell find . -name '*.go')
 GOPKGS      := $(shell go list ./... | grep -v "/test")
 GOTEST      := -race -cover -covermode=atomic -v $(GOPKGS)
+GOFLAGS     := "-X github.com/speechly/slu-client/internal/application.BuildVersion=$(VERSION) -X github.com/speechly/slu-client/internal/application.BuildTime=$(TIME) -X github.com/speechly/slu-client/internal/application.BuildAuthor=$(AUTHOR)"
 
 all: vendor proto lint test build
 .PHONY: all
@@ -25,10 +31,10 @@ test:
 .PHONY: test
 
 $(INSTALLNAME): $(SOURCES)
-	go build -i -o $(INSTALLNAME) $(CMD)
+	go build -i -o $(INSTALLNAME) -ldflags $(GOFLAGS) $(CMD)
 
 $(BUILDNAME): $(SOURCES)
-	go build -o $(BUILDNAME) $(CMD)
+	go build -o $(BUILDNAME) -ldflags $(GOFLAGS) $(CMD)
 
 $(PROTONAME): api/speechly/*.proto
 	protoc \

--- a/cmd/command/version.go
+++ b/cmd/command/version.go
@@ -1,0 +1,23 @@
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/speechly/slu-client/internal/application"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print application's version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Build number:\t\t%s\n", application.BuildVersion)
+		fmt.Printf("Build author:\t\t%s\n", application.BuildAuthor)
+		fmt.Printf("Build timestamp:\t%s\n", application.BuildTime)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/application/version.go
+++ b/internal/application/version.go
@@ -1,0 +1,8 @@
+package application
+
+// Build flags, set by ldflags.
+var (
+	BuildVersion string
+	BuildTime    string
+	BuildAuthor  string
+)

--- a/pkg/speechly/slu/handler.go
+++ b/pkg/speechly/slu/handler.go
@@ -232,6 +232,8 @@ func (r *ctxHandler) run() {
 					return err
 				}
 
+				r.log.Debug("received response from API", res)
+
 				var (
 					id  = res.GetAudioContext()
 					sid = res.GetSegmentId()

--- a/pkg/speechly/slu/handler.go
+++ b/pkg/speechly/slu/handler.go
@@ -143,20 +143,12 @@ func newCtxHandler(
 }
 
 func (r *ctxHandler) Read() (AudioContext, error) {
-	select {
-	case c, more := <-r.res:
-		if !more {
-			return AudioContext{}, io.EOF
-		}
-
-		return c, nil
-	case <-r.done:
-		if r.runErr == nil {
-			return AudioContext{}, io.EOF
-		}
-
-		return AudioContext{}, r.runErr
+	c, more := <-r.res
+	if !more {
+		return c, io.EOF
 	}
+
+	return c, nil
 }
 
 func (r *ctxHandler) Close() error {


### PR DESCRIPTION
### What

* Ensure that context handler reads drain the channel
* Add debug output of API responses
* Implement a version command

### Why

* Fixes the sometimes omitted final response
* Enables one to see low-level responses in debug mode
* Enables one to know which source code version the binary is using

